### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build-and-push-docker-image:
+    name: Build Docker image and push to repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and maybe push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          # Build on feature branches / merge requests. Push only if on main branch.
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest


### PR DESCRIPTION
This PR adds a `.github/workflows/ci.yml` GitHub Actions config file that, on push to `main` or pull request into `main`, automatically builds and tags a Docker image using the `Dockerfile` defined in the repo. On push to `main`, the CI script will also push the resulting Docker image to the Docker Hub registry defined in the `secrets.DOCKERHUB_USERNAME` secret.